### PR TITLE
make Channel interface mockable

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -34,6 +34,13 @@ type Channel interface {
 	Trigger(event string, data interface{}) error
 }
 
+// internalChannel represents the Channel interface used internally
+type internalChannel interface {
+	Channel
+
+	handleEvent(event string, data json.RawMessage)
+}
+
 type boundDataChans map[chan json.RawMessage]struct{}
 
 type channel struct {

--- a/channel.go
+++ b/channel.go
@@ -32,8 +32,6 @@ type Channel interface {
 	Unbind(event string, chans ...chan json.RawMessage)
 	// Trigger sends an event to the channel.
 	Trigger(event string, data interface{}) error
-
-	handleEvent(event string, data json.RawMessage)
 }
 
 type boundDataChans map[chan json.RawMessage]struct{}

--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ const (
 
 type boundEventChans map[chan Event]struct{}
 
-type subscribedChannels map[string]Channel
+type subscribedChannels map[string]internalChannel
 
 // Client represents a Pusher websocket client. After creating an instance, it
 // is necessary to call Connect to establish the connection with Pusher. Calling

--- a/client_test.go
+++ b/client_test.go
@@ -199,7 +199,7 @@ func TestClientSubscribe(t *testing.T) {
 		channelName := "foo"
 		ch := &channel{name: channelName, subscribed: true}
 		client := &Client{
-			subscribedChannels: map[string]Channel{channelName: ch},
+			subscribedChannels: map[string]internalChannel{channelName: ch},
 			ws:                 ws,
 		}
 		defer client.Disconnect()
@@ -243,7 +243,7 @@ func TestClientSubscribe(t *testing.T) {
 		}
 
 		client := &Client{
-			subscribedChannels: map[string]Channel{},
+			subscribedChannels: map[string]internalChannel{},
 			ws:                 ws,
 			connected:          true,
 		}
@@ -295,7 +295,7 @@ func TestClientSubscribe(t *testing.T) {
 		}))
 
 		client := &Client{
-			subscribedChannels: map[string]Channel{},
+			subscribedChannels: map[string]internalChannel{},
 			ws:                 ws,
 			connected:          true,
 			AuthURL:            authSrv.URL,
@@ -348,7 +348,7 @@ func TestClientSubscribe(t *testing.T) {
 		}))
 
 		client := &Client{
-			subscribedChannels: map[string]Channel{},
+			subscribedChannels: map[string]internalChannel{},
 			ws:                 ws,
 			connected:          true,
 			AuthURL:            authSrv.URL,
@@ -380,7 +380,7 @@ func TestClientUnsubscribe(t *testing.T) {
 
 	ch := &channel{name: "foo"}
 	client := &Client{
-		subscribedChannels: map[string]Channel{"foo": ch},
+		subscribedChannels: map[string]internalChannel{"foo": ch},
 		ws:                 ws,
 	}
 	defer client.Disconnect()
@@ -574,7 +574,7 @@ func TestClientListen(t *testing.T) {
 			boundEvents: map[string]boundEventChans{
 				wantEvent.Event: {eventChan: struct{}{}},
 			},
-			subscribedChannels: map[string]Channel{
+			subscribedChannels: map[string]internalChannel{
 				wantEvent.Channel: &channel{
 					boundEvents: map[string]boundDataChans{
 						wantEvent.Event: {dataChan: struct{}{}},


### PR DESCRIPTION
by removing `handleEvent`  from the `Channel`  interface and moving it to the new `internalChannel` interface.

Having a private receiver on an exported interface makes it impossible to mock outside of the original package.