### PR TITLE
start v1 branch, add deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@
 [![Travis CI Build Status](https://travis-ci.org/goguardian/pusher-ws-go.svg?branch=master)](https://travis-ci.org/goguardian/pusher-ws-go)
 [![Codecov](https://codecov.io/gh/goguardian/pusher-ws-go/branch/master/graph/badge.svg)](https://codecov.io/gh/goguardian/pusher-ws-go)
 
+> NOTE: version 1 of this package is in maintanance mode. Use V2 instead (`github.com/goguardian/pusher-ws-go/v2`).
+
 This package implements a Pusher websocket client. It is based on the official [Pusher JavaScript client libary](https://github.com/pusher/pusher-js) as well as [go-pusher](https://github.com/toorop/go-pusher).
 
 ## Installation
-	$ go get github.com/goguardian/pusher-ws-go
+
+```sh
+go get github.com/goguardian/pusher-ws-go
+```
 
 ## Features
 
@@ -29,3 +34,7 @@ This package implements a Pusher websocket client. It is based on the official [
 * [x] Presence channel member data
 * [ ] Cancel subscribing
 * [ ] Handle pong timeout/reconnect
+
+## Maintenance Mode
+
+Version 1 branch has reached end of life and will only receive minor fixes in the future. Version 1 code is now hosted in the `v1` branch. `master` branch contains version 2 of the library. Please consider upgrading.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/goguardian/pusher-ws-go/v2 instead.
 module github.com/goguardian/pusher-ws-go
 
 go 1.17


### PR DESCRIPTION
This is a placeholder PR. It's not intended to be merged, we'll keep `v1` branch open after `v2` is released.
The change in this PR should be ignored for now.