### PR TITLE
fix: goroutine leak in Client.resetActivityTimer method

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -278,7 +278,7 @@ func TestChannelTrigger(t *testing.T) {
 
 	client := &Client{
 		ws:                 ws,
-		activityTimerReset: make(chan struct{}),
+		activityTimerReset: make(chan struct{}, 1),
 	}
 	defer client.Disconnect()
 

--- a/client_test.go
+++ b/client_test.go
@@ -53,13 +53,14 @@ func TestClientIsConnected(t *testing.T) {
 }
 
 func TestClientResetActivityTimer(t *testing.T) {
-	resetChan := make(chan struct{})
-	client := &Client{activityTimerReset: resetChan}
+	client := &Client{
+		activityTimerReset: make(chan struct{}, 1),
+	}
 
-	wg := &sync.WaitGroup{}
+	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		<-resetChan
+		<-client.activityTimerReset
 		wg.Done()
 	}()
 
@@ -176,7 +177,7 @@ func TestClientSendEvent(t *testing.T) {
 
 	client := &Client{
 		ws:                 ws,
-		activityTimerReset: make(chan struct{}),
+		activityTimerReset: make(chan struct{}, 1),
 	}
 	defer client.Disconnect()
 
@@ -447,11 +448,12 @@ func TestClientHeartbeat(t *testing.T) {
 		timeChan := make(chan time.Time)
 		client := &Client{
 			connected:          false,
-			activityTimerReset: make(chan struct{}),
+			activityTimerReset: make(chan struct{}, 1),
 			activityTimer:      &time.Timer{C: timeChan},
 		}
 
 		go func() {
+			client.activityTimerReset <- struct{}{}
 			client.activityTimerReset <- struct{}{}
 			t.Errorf("Expected not to block on send to activityTimerReset, but message was received")
 		}()
@@ -474,7 +476,7 @@ func TestClientHeartbeat(t *testing.T) {
 
 		client := &Client{
 			connected:          true,
-			activityTimerReset: make(chan struct{}),
+			activityTimerReset: make(chan struct{}, 1),
 			activityTimer:      time.NewTimer(1 * time.Hour),
 			activityTimeout:    0,
 			ws:                 ws,
@@ -487,7 +489,6 @@ func TestClientHeartbeat(t *testing.T) {
 		client.activityTimerReset <- struct{}{}
 
 		<-client.activityTimer.C
-
 	})
 
 	t.Run("timerExpire", func(t *testing.T) {
@@ -522,6 +523,34 @@ func TestClientHeartbeat(t *testing.T) {
 		go client.heartbeat()
 
 		wg.Wait()
+	})
+
+	t.Run("timerReset panic", func(t *testing.T) {
+		srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {}))
+		defer srv.Close()
+
+		wsURL := strings.Replace(srv.URL, "http", "ws", 1)
+		ws, err := websocket.Dial(wsURL, "ws", localOrigin)
+		if err != nil {
+			panic(err)
+		}
+
+		client := &Client{
+			connected:          true,
+			activityTimerReset: make(chan struct{}, 1),
+			activityTimer:      time.NewTimer(1 * time.Hour),
+			activityTimeout:    0,
+			ws:                 ws,
+		}
+
+		go client.heartbeat()
+		runtime.Gosched()
+
+		// client.Disconnect()
+		// client.activityTimerReset <- struct{}{}
+		client.resetActivityTimer()
+
+		<-client.activityTimer.C
 	})
 }
 
@@ -812,6 +841,22 @@ func TestClientConnect(t *testing.T) {
 		wantTimeout := time.Duration(wantConnData.ActivityTimeout) * time.Second
 		if client.activityTimeout != wantTimeout {
 			t.Errorf("Expected client activity timeout to be %v, got %v", wantTimeout, client.activityTimeout)
+		}
+		if client.activityTimer == nil {
+			t.Errorf("Expected client activity timer to be non-nil")
+		}
+		if client.activityTimerReset == nil {
+			t.Errorf("Expected client activity timer reset channel to be non-nil")
+		}
+		if cap(client.activityTimerReset) != 1 {
+			t.Errorf("Expected client activity timer reset channel to have capacity 1, got %v",
+				cap(client.activityTimerReset))
+		}
+		if client.boundEvents == nil {
+			t.Errorf("Expected client bound events to be non-nil")
+		}
+		if client.subscribedChannels == nil {
+			t.Errorf("Expected client subscribed channels to be non-nil")
 		}
 	})
 }


### PR DESCRIPTION
This PR fixes a goroutine leak in `Client.resetActivityTimer` func.

The use case for `Client` is to be first instantiated (e.g. via `Client{}`) and then to call `Client.Connect`. The `Connect` method populates additional internal fields of `Client` when connection is established successfully.
An instance of `Client` created this way always had `activityTimerReset` channel not initialized (`nil`). This led to always blocked writes and reads from this channel.

`Client.resetActivityTimer` tried to write to the `activityTimerReset` channel in goroutine. Because of the `nil` channel, the writes could not finish and the goroutine would not return creating a goroutine leak.

The reads from `activityTimerReset` done in `Client.heartbeat` method were also blocked. Most likely, that essentially disabled heartbeat exchange after first attempt.

Here's a quick example: https://go.dev/play/p/bFu8azDKlBl.

This PR makes sure the `activityTimerReset` is initialized by `Client.Connect` method. It also changes the channel to be buffered (buffer size 1) and removes a goroutine wrap.

The `activityTimerReset` channel is used to send a signal that the timer needs to be reset at a certain moment. We use a non-blocking write implemented with `select-default` to remove the need for a goroutine. The buffered channel of size 1 allows us to not loose reset signal when `Client.heartbeat` executes its second `case` statement – sending ping message to websocket. Once exchange finishes, `Client.heartbeat` will read from `activityTimerReset` and will reset the timer.